### PR TITLE
Persistencia de oportunidades no MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@ O MVP do RadarBolsa organiza oportunidades priorizadas por score, setor e tese r
 |   `-- mysql/init/001_create_schema.sql
 |-- src/
 |   |-- backend/RadarBolsa.Api
+|   |-- backend/RadarBolsa.Application
+|   |-- backend/RadarBolsa.Domain
+|   |-- backend/RadarBolsa.Infrastructure
 |   `-- frontend
 |-- docker-compose.yml
-`-- RadarBolsa.slnx
+`-- README.md
 ```
 
 ## Entregas desta etapa
-- API inicial com `/health` e `/api/opportunities`
+- API estruturada em Clean Architecture simples com `/health` e `/api/opportunities`
 - Frontend Vue com painel demonstrativo
 - Script inicial de banco para ativos monitorados e oportunidades
+- Seed inicial de oportunidades no MySQL para validacao local
 - Docker Compose com MySQL e API
 
 ## Como executar
@@ -61,7 +65,9 @@ O `docker-compose.yml` define o ambiente local inicial do projeto com:
 - `api`: backend ASP.NET Core exposto em `http://localhost:8081`
 - rede dedicada `radarbolsa-network` para comunicacao entre os servicos
 
-Nesta etapa, o `docker compose` sobe MySQL e API. O frontend roda localmente via Vite.
+Nesta etapa, o `docker compose` sobe MySQL e API com seed inicial de oportunidades. O frontend roda localmente via Vite.
+
+Os scripts em `infra/mysql/init` sao executados automaticamente na primeira inicializacao de um volume novo do MySQL.
 
 ## Validacao rapida
 ```powershell
@@ -78,7 +84,7 @@ curl.exe -i http://localhost:8081/health
 - `GET /api/opportunities?sector=Energia`
 
 ## Proximas etapas
-1. Conectar a API ao MySQL.
-2. Substituir dados mockados por repositorio real.
-3. Adicionar cadastro e monitoramento de ativos.
+1. Adicionar seed inicial de oportunidades no MySQL.
+2. Criar cadastro e monitoramento de ativos.
+3. Expandir filtros e ordenacao da API.
 4. Evoluir para ingestao automatizada e alertas.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -22,7 +22,10 @@ Sistema para rastrear e analisar oportunidades de investimento, com foco em um M
 - Estruturar o repositorio para expansao futura sem reescrita imediata.
 
 ## Estrutura Inicial
-- `src/backend/RadarBolsa.Api`: API ASP.NET Core com endpoints iniciais.
+- `src/backend/RadarBolsa.Domain`: entidades centrais do dominio.
+- `src/backend/RadarBolsa.Application`: casos de uso e contratos da aplicacao.
+- `src/backend/RadarBolsa.Infrastructure`: persistencia MySQL e integracoes.
+- `src/backend/RadarBolsa.Api`: API ASP.NET Core com endpoints e composicao.
 - `src/frontend`: aplicacao Vue 3 para o painel inicial.
 - `infra/mysql`: scripts de banco para ambiente local.
 - `docker-compose.yml`: orquestracao dos servicos base.
@@ -30,11 +33,11 @@ Sistema para rastrear e analisar oportunidades de investimento, com foco em um M
 
 ## Entrega Desta Etapa
 - Estrutura inicial do monorepo.
+- Backend organizado em Clean Architecture simples e pragmatica.
 - API inicial com endpoints de saude e oportunidades.
 - Frontend Vue com painel demonstrativo.
 - Base de Docker e script inicial do MySQL.
 
 ## Proxima Etapa Recomendada
-- Persistir oportunidades em MySQL.
-- Substituir dados mockados por repositorio real.
+- Popular oportunidades no MySQL com seed inicial.
 - Adicionar ingestao de ativos monitorados e filtros por perfil.

--- a/infra/mysql/init/002_seed_opportunities.sql
+++ b/infra/mysql/init/002_seed_opportunities.sql
@@ -1,0 +1,104 @@
+USE radarbolsa;
+
+INSERT INTO tracked_assets (ticker, company_name, sector, is_active)
+VALUES
+    ('PETR4', 'Petrobras PN', 'Energia', b'1'),
+    ('ITUB4', 'Itau Unibanco PN', 'Financeiro', b'1'),
+    ('WEGE3', 'WEG ON', 'Industria', b'1'),
+    ('TAEE11', 'Taesa Unit', 'Utilidade Publica', b'1')
+ON DUPLICATE KEY UPDATE
+    company_name = VALUES(company_name),
+    sector = VALUES(sector),
+    is_active = VALUES(is_active);
+
+INSERT INTO opportunities (
+    tracked_asset_id,
+    current_price,
+    target_price,
+    score,
+    thesis,
+    captured_at)
+SELECT
+    ta.id,
+    31.42,
+    37.80,
+    84,
+    'Geracao de caixa consistente, dividendos relevantes e desconto frente aos pares.',
+    '2026-04-29 12:00:00'
+FROM tracked_assets ta
+WHERE ta.ticker = 'PETR4'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM opportunities o
+      WHERE o.tracked_asset_id = ta.id
+        AND o.captured_at = '2026-04-29 12:00:00'
+  );
+
+INSERT INTO opportunities (
+    tracked_asset_id,
+    current_price,
+    target_price,
+    score,
+    thesis,
+    captured_at)
+SELECT
+    ta.id,
+    34.15,
+    39.60,
+    81,
+    'Rentabilidade elevada, qualidade operacional e resiliencia em ciclos distintos.',
+    '2026-04-29 12:05:00'
+FROM tracked_assets ta
+WHERE ta.ticker = 'ITUB4'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM opportunities o
+      WHERE o.tracked_asset_id = ta.id
+        AND o.captured_at = '2026-04-29 12:05:00'
+  );
+
+INSERT INTO opportunities (
+    tracked_asset_id,
+    current_price,
+    target_price,
+    score,
+    thesis,
+    captured_at)
+SELECT
+    ta.id,
+    48.90,
+    55.00,
+    78,
+    'Execucao recorrente e exposicao a tendencias de eletrificacao e eficiencia.',
+    '2026-04-29 12:10:00'
+FROM tracked_assets ta
+WHERE ta.ticker = 'WEGE3'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM opportunities o
+      WHERE o.tracked_asset_id = ta.id
+        AND o.captured_at = '2026-04-29 12:10:00'
+  );
+
+INSERT INTO opportunities (
+    tracked_asset_id,
+    current_price,
+    target_price,
+    score,
+    thesis,
+    captured_at)
+SELECT
+    ta.id,
+    34.70,
+    38.10,
+    74,
+    'Receita previsivel, foco em transmissao e perfil defensivo para carteira.',
+    '2026-04-29 12:15:00'
+FROM tracked_assets ta
+WHERE ta.ticker = 'TAEE11'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM opportunities o
+      WHERE o.tracked_asset_id = ta.id
+        AND o.captured_at = '2026-04-29 12:15:00'
+  );

--- a/src/backend/RadarBolsa.Api/Configuration/CorsPolicies.cs
+++ b/src/backend/RadarBolsa.Api/Configuration/CorsPolicies.cs
@@ -1,0 +1,6 @@
+namespace RadarBolsa.Api.Configuration;
+
+public static class CorsPolicies
+{
+    public const string Frontend = "frontend";
+}

--- a/src/backend/RadarBolsa.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/src/backend/RadarBolsa.Api/Configuration/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+namespace RadarBolsa.Api.Configuration;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddFrontendCors(this IServiceCollection services)
+    {
+        services.AddCors(options =>
+        {
+            options.AddPolicy(CorsPolicies.Frontend, policy =>
+            {
+                policy
+                    .WithOrigins("http://localhost:5173")
+                    .AllowAnyHeader()
+                    .AllowAnyMethod();
+            });
+        });
+
+        return services;
+    }
+}

--- a/src/backend/RadarBolsa.Api/Contracts/HealthResponse.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/HealthResponse.cs
@@ -1,0 +1,7 @@
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed record HealthResponse(
+    string Status,
+    string Service,
+    string Database,
+    DateTimeOffset Timestamp);

--- a/src/backend/RadarBolsa.Api/Contracts/OpportunityResponse.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/OpportunityResponse.cs
@@ -1,0 +1,17 @@
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed record OpportunityResponse(
+    string Ticker,
+    string CompanyName,
+    string Sector,
+    decimal CurrentPrice,
+    decimal TargetPrice,
+    int Score,
+    string Thesis,
+    DateTimeOffset CapturedAt)
+{
+    public decimal UpsidePercent =>
+        CurrentPrice == 0
+            ? 0
+            : Math.Round(((TargetPrice - CurrentPrice) / CurrentPrice) * 100, 2);
+}

--- a/src/backend/RadarBolsa.Api/Dockerfile
+++ b/src/backend/RadarBolsa.Api/Dockerfile
@@ -1,6 +1,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
+COPY ["src/backend/RadarBolsa.Domain/RadarBolsa.Domain.csproj", "src/backend/RadarBolsa.Domain/"]
+COPY ["src/backend/RadarBolsa.Application/RadarBolsa.Application.csproj", "src/backend/RadarBolsa.Application/"]
+COPY ["src/backend/RadarBolsa.Infrastructure/RadarBolsa.Infrastructure.csproj", "src/backend/RadarBolsa.Infrastructure/"]
 COPY ["src/backend/RadarBolsa.Api/RadarBolsa.Api.csproj", "src/backend/RadarBolsa.Api/"]
 RUN dotnet restore "src/backend/RadarBolsa.Api/RadarBolsa.Api.csproj"
 

--- a/src/backend/RadarBolsa.Api/Endpoints/HealthEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/HealthEndpoints.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using RadarBolsa.Api.Contracts;
+using RadarBolsa.Application.Health;
+
+namespace RadarBolsa.Api.Endpoints;
+
+public static class HealthEndpoints
+{
+    public static IEndpointRouteBuilder MapHealthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/health", GetHealth)
+            .WithName("GetHealth");
+
+        return app;
+    }
+
+    private static async Task<Results<Ok<HealthResponse>, ProblemHttpResult>> GetHealth(
+        GetHealthStatusUseCase useCase,
+        CancellationToken cancellationToken)
+    {
+        var healthStatus = await useCase.ExecuteAsync(cancellationToken);
+
+        if (!healthStatus.IsHealthy)
+        {
+            return TypedResults.Problem(
+                title: "Database connectivity failed",
+                detail: healthStatus.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return TypedResults.Ok(
+            new HealthResponse(
+                "ok",
+                "radarbolsa-api",
+                healthStatus.Database,
+                healthStatus.CheckedAt));
+    }
+}

--- a/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using RadarBolsa.Api.Contracts;
+using RadarBolsa.Api.Mappings;
+using RadarBolsa.Application.Opportunities;
+
+namespace RadarBolsa.Api.Endpoints;
+
+public static class OpportunityEndpoints
+{
+    public static IEndpointRouteBuilder MapOpportunityEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/opportunities", GetOpportunities)
+            .WithName("GetOpportunities");
+
+        return app;
+    }
+
+    private static async Task<Ok<OpportunityResponse[]>> GetOpportunities(
+        int? minScore,
+        string? sector,
+        GetOpportunitiesUseCase useCase,
+        CancellationToken cancellationToken)
+    {
+        var opportunities = await useCase.ExecuteAsync(
+            minScore,
+            sector,
+            cancellationToken);
+
+        return TypedResults.Ok(
+            opportunities
+                .Select(item => item.ToResponse())
+                .ToArray());
+    }
+}

--- a/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
+++ b/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
@@ -1,0 +1,18 @@
+using RadarBolsa.Api.Contracts;
+using RadarBolsa.Domain.Opportunities;
+
+namespace RadarBolsa.Api.Mappings;
+
+internal static class ApiContractMappings
+{
+    public static OpportunityResponse ToResponse(this Opportunity opportunity) =>
+        new(
+            opportunity.Ticker,
+            opportunity.CompanyName,
+            opportunity.Sector,
+            opportunity.CurrentPrice,
+            opportunity.TargetPrice,
+            opportunity.Score,
+            opportunity.Thesis,
+            opportunity.CapturedAt);
+}

--- a/src/backend/RadarBolsa.Api/Program.cs
+++ b/src/backend/RadarBolsa.Api/Program.cs
@@ -1,163 +1,19 @@
-using MySqlConnector;
-using Microsoft.AspNetCore.Http.HttpResults;
+using RadarBolsa.Api.Configuration;
+using RadarBolsa.Api.Endpoints;
+using RadarBolsa.Application;
+using RadarBolsa.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("frontend", policy =>
-    {
-        policy
-            .WithOrigins("http://localhost:5173")
-            .AllowAnyHeader()
-            .AllowAnyMethod();
-    });
-});
-
-builder.Services.AddSingleton<DatabaseConnectionProbe>();
+builder.Services.AddFrontendCors();
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure();
 
 var app = builder.Build();
 
-app.UseCors("frontend");
+app.UseCors(CorsPolicies.Frontend);
 
-var capturedAt = DateTimeOffset.UtcNow;
-var opportunities = new[]
-{
-    new OpportunityResponse(
-        "PETR4",
-        "Petrobras PN",
-        "Energia",
-        31.42m,
-        37.80m,
-        84,
-        "Geracao de caixa consistente, dividendos relevantes e desconto frente aos pares.",
-        capturedAt),
-    new OpportunityResponse(
-        "ITUB4",
-        "Itau Unibanco PN",
-        "Financeiro",
-        34.15m,
-        39.60m,
-        81,
-        "Rentabilidade elevada, qualidade operacional e resiliencia em ciclos distintos.",
-        capturedAt),
-    new OpportunityResponse(
-        "WEGE3",
-        "WEG ON",
-        "Industria",
-        48.90m,
-        55.00m,
-        78,
-        "Execucao recorrente e exposicao a tendencias de eletrificacao e eficiencia.",
-        capturedAt),
-    new OpportunityResponse(
-        "TAEE11",
-        "Taesa Unit",
-        "Utilidade Publica",
-        34.70m,
-        38.10m,
-        74,
-        "Receita previsivel, foco em transmissao e perfil defensivo para carteira.",
-        capturedAt)
-};
-
-app.MapGet("/health", GetHealth);
-
-app.MapGet("/api/opportunities", (int? minScore, string? sector) =>
-{
-    IEnumerable<OpportunityResponse> query = opportunities;
-
-    if (minScore.HasValue)
-    {
-        query = query.Where(item => item.Score >= minScore.Value);
-    }
-
-    if (!string.IsNullOrWhiteSpace(sector))
-    {
-        query = query.Where(item =>
-            item.Sector.Equals(sector, StringComparison.OrdinalIgnoreCase));
-    }
-
-    return TypedResults.Ok(query.OrderByDescending(item => item.Score));
-})
-.WithName("GetOpportunities");
-
-static async Task<Microsoft.AspNetCore.Http.HttpResults.Results<Ok<HealthResponse>, ProblemHttpResult>> GetHealth(
-    DatabaseConnectionProbe databaseConnectionProbe,
-    CancellationToken cancellationToken)
-{
-    var databaseCheck = await databaseConnectionProbe.CheckAsync(cancellationToken);
-
-    if (!databaseCheck.IsHealthy)
-    {
-        return TypedResults.Problem(
-            title: "Database connectivity failed",
-            detail: databaseCheck.ErrorMessage,
-            statusCode: StatusCodes.Status503ServiceUnavailable);
-    }
-
-    return TypedResults.Ok(
-        new HealthResponse(
-            "ok",
-            "radarbolsa-api",
-            "ok",
-            DateTimeOffset.UtcNow));
-}
+app.MapHealthEndpoints();
+app.MapOpportunityEndpoints();
 
 app.Run();
-
-internal sealed record OpportunityResponse(
-    string Ticker,
-    string CompanyName,
-    string Sector,
-    decimal CurrentPrice,
-    decimal TargetPrice,
-    int Score,
-    string Thesis,
-    DateTimeOffset CapturedAt)
-{
-    public decimal UpsidePercent =>
-        CurrentPrice == 0
-            ? 0
-            : Math.Round(((TargetPrice - CurrentPrice) / CurrentPrice) * 100, 2);
-}
-
-internal sealed record HealthResponse(
-    string Status,
-    string Service,
-    string Database,
-    DateTimeOffset Timestamp);
-
-internal sealed class DatabaseConnectionProbe(IConfiguration configuration)
-{
-    private readonly string _connectionString =
-        configuration.GetConnectionString("RadarBolsa")
-        ?? throw new InvalidOperationException(
-            "Connection string 'RadarBolsa' was not configured.");
-
-    public async Task<DatabaseHealthResult> CheckAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            await using var connection = new MySqlConnection(_connectionString);
-            await connection.OpenAsync(cancellationToken);
-
-            await using var command = new MySqlCommand("SELECT 1;", connection);
-            await command.ExecuteScalarAsync(cancellationToken);
-
-            return DatabaseHealthResult.Healthy();
-        }
-        catch (Exception exception)
-        {
-            return DatabaseHealthResult.Unhealthy(exception.Message);
-        }
-    }
-}
-
-internal sealed record DatabaseHealthResult(bool IsHealthy, string? ErrorMessage)
-{
-    public static DatabaseHealthResult Healthy() => new(true, null);
-
-    public static DatabaseHealthResult Unhealthy(string errorMessage) =>
-        new(false, errorMessage);
-}

--- a/src/backend/RadarBolsa.Application/Abstractions/Health/IDatabaseHealthChecker.cs
+++ b/src/backend/RadarBolsa.Application/Abstractions/Health/IDatabaseHealthChecker.cs
@@ -1,0 +1,8 @@
+using RadarBolsa.Application.Health;
+
+namespace RadarBolsa.Application.Abstractions.Health;
+
+public interface IDatabaseHealthChecker
+{
+    Task<DatabaseHealthStatus> CheckAsync(CancellationToken cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/Abstractions/Persistence/IOpportunityReadRepository.cs
+++ b/src/backend/RadarBolsa.Application/Abstractions/Persistence/IOpportunityReadRepository.cs
@@ -1,0 +1,11 @@
+using RadarBolsa.Application.Opportunities;
+using RadarBolsa.Domain.Opportunities;
+
+namespace RadarBolsa.Application.Abstractions.Persistence;
+
+public interface IOpportunityReadRepository
+{
+    Task<IReadOnlyList<Opportunity>> ListAsync(
+        OpportunityFilters filters,
+        CancellationToken cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/DependencyInjection.cs
+++ b/src/backend/RadarBolsa.Application/DependencyInjection.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using RadarBolsa.Application.Health;
+using RadarBolsa.Application.Opportunities;
+
+namespace RadarBolsa.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddScoped<GetHealthStatusUseCase>();
+        services.AddScoped<GetOpportunitiesUseCase>();
+
+        return services;
+    }
+}

--- a/src/backend/RadarBolsa.Application/Health/DatabaseHealthStatus.cs
+++ b/src/backend/RadarBolsa.Application/Health/DatabaseHealthStatus.cs
@@ -1,0 +1,16 @@
+namespace RadarBolsa.Application.Health;
+
+public sealed record DatabaseHealthStatus(
+    bool IsHealthy,
+    string Database,
+    string? ErrorMessage,
+    DateTimeOffset CheckedAt)
+{
+    public static DatabaseHealthStatus Healthy(DateTimeOffset checkedAt) =>
+        new(true, "ok", null, checkedAt);
+
+    public static DatabaseHealthStatus Unhealthy(
+        string errorMessage,
+        DateTimeOffset checkedAt) =>
+        new(false, "unavailable", errorMessage, checkedAt);
+}

--- a/src/backend/RadarBolsa.Application/Health/GetHealthStatusUseCase.cs
+++ b/src/backend/RadarBolsa.Application/Health/GetHealthStatusUseCase.cs
@@ -1,0 +1,9 @@
+using RadarBolsa.Application.Abstractions.Health;
+
+namespace RadarBolsa.Application.Health;
+
+public sealed class GetHealthStatusUseCase(IDatabaseHealthChecker databaseHealthChecker)
+{
+    public Task<DatabaseHealthStatus> ExecuteAsync(CancellationToken cancellationToken) =>
+        databaseHealthChecker.CheckAsync(cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/Opportunities/GetOpportunitiesUseCase.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/GetOpportunitiesUseCase.cs
@@ -1,0 +1,20 @@
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Domain.Opportunities;
+
+namespace RadarBolsa.Application.Opportunities;
+
+public sealed class GetOpportunitiesUseCase(
+    IOpportunityReadRepository opportunityReadRepository)
+{
+    public Task<IReadOnlyList<Opportunity>> ExecuteAsync(
+        int? minScore,
+        string? sector,
+        CancellationToken cancellationToken)
+    {
+        var filters = new OpportunityFilters(
+            minScore,
+            string.IsNullOrWhiteSpace(sector) ? null : sector.Trim());
+
+        return opportunityReadRepository.ListAsync(filters, cancellationToken);
+    }
+}

--- a/src/backend/RadarBolsa.Application/Opportunities/OpportunityFilters.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/OpportunityFilters.cs
@@ -1,0 +1,3 @@
+namespace RadarBolsa.Application.Opportunities;
+
+public sealed record OpportunityFilters(int? MinScore, string? Sector);

--- a/src/backend/RadarBolsa.Application/RadarBolsa.Application.csproj
+++ b/src/backend/RadarBolsa.Application/RadarBolsa.Application.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -7,9 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RadarBolsa.Application\RadarBolsa.Application.csproj" />
     <ProjectReference Include="..\RadarBolsa.Domain\RadarBolsa.Domain.csproj" />
-    <ProjectReference Include="..\RadarBolsa.Infrastructure\RadarBolsa.Infrastructure.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/src/backend/RadarBolsa.Domain/Opportunities/Opportunity.cs
+++ b/src/backend/RadarBolsa.Domain/Opportunities/Opportunity.cs
@@ -1,0 +1,17 @@
+namespace RadarBolsa.Domain.Opportunities;
+
+public sealed record Opportunity(
+    string Ticker,
+    string CompanyName,
+    string Sector,
+    decimal CurrentPrice,
+    decimal TargetPrice,
+    int Score,
+    string Thesis,
+    DateTimeOffset CapturedAt)
+{
+    public decimal UpsidePercent =>
+        CurrentPrice == 0
+            ? 0
+            : Math.Round(((TargetPrice - CurrentPrice) / CurrentPrice) * 100, 2);
+}

--- a/src/backend/RadarBolsa.Domain/RadarBolsa.Domain.csproj
+++ b/src/backend/RadarBolsa.Domain/RadarBolsa.Domain.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/backend/RadarBolsa.Infrastructure/DependencyInjection.cs
+++ b/src/backend/RadarBolsa.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using RadarBolsa.Application.Abstractions.Health;
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Infrastructure.Health;
+using RadarBolsa.Infrastructure.Persistence;
+using RadarBolsa.Infrastructure.Persistence.Opportunities;
+
+namespace RadarBolsa.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        services.AddSingleton<IRadarBolsaDbConnectionFactory, RadarBolsaDbConnectionFactory>();
+        services.AddSingleton<IDatabaseHealthChecker, DatabaseHealthChecker>();
+        services.AddScoped<IOpportunityReadRepository, MySqlOpportunityReadRepository>();
+
+        return services;
+    }
+}

--- a/src/backend/RadarBolsa.Infrastructure/Health/DatabaseHealthChecker.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Health/DatabaseHealthChecker.cs
@@ -1,0 +1,30 @@
+using MySqlConnector;
+using RadarBolsa.Application.Abstractions.Health;
+using RadarBolsa.Application.Health;
+using RadarBolsa.Infrastructure.Persistence;
+
+namespace RadarBolsa.Infrastructure.Health;
+
+internal sealed class DatabaseHealthChecker(
+    IRadarBolsaDbConnectionFactory connectionFactory) : IDatabaseHealthChecker
+{
+    public async Task<DatabaseHealthStatus> CheckAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = connectionFactory.CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new MySqlCommand("SELECT 1;", connection);
+            await command.ExecuteScalarAsync(cancellationToken);
+
+            return DatabaseHealthStatus.Healthy(DateTimeOffset.UtcNow);
+        }
+        catch (Exception exception)
+        {
+            return DatabaseHealthStatus.Unhealthy(
+                exception.Message,
+                DateTimeOffset.UtcNow);
+        }
+    }
+}

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/IRadarBolsaDbConnectionFactory.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/IRadarBolsaDbConnectionFactory.cs
@@ -1,0 +1,8 @@
+using MySqlConnector;
+
+namespace RadarBolsa.Infrastructure.Persistence;
+
+internal interface IRadarBolsaDbConnectionFactory
+{
+    MySqlConnection CreateConnection();
+}

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/Opportunities/MySqlOpportunityReadRepository.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/Opportunities/MySqlOpportunityReadRepository.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using MySqlConnector;
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Application.Opportunities;
+using RadarBolsa.Domain.Opportunities;
+
+namespace RadarBolsa.Infrastructure.Persistence.Opportunities;
+
+internal sealed class MySqlOpportunityReadRepository(
+    IRadarBolsaDbConnectionFactory connectionFactory) : IOpportunityReadRepository
+{
+    public async Task<IReadOnlyList<Opportunity>> ListAsync(
+        OpportunityFilters filters,
+        CancellationToken cancellationToken)
+    {
+        var sql = new StringBuilder(
+            """
+            SELECT
+                ta.ticker,
+                ta.company_name,
+                ta.sector,
+                o.current_price,
+                o.target_price,
+                o.score,
+                o.thesis,
+                o.captured_at
+            FROM opportunities o
+            INNER JOIN tracked_assets ta ON ta.id = o.tracked_asset_id
+            WHERE ta.is_active = b'1'
+            """);
+
+        if (filters.MinScore.HasValue)
+        {
+            sql.AppendLine(" AND o.score >= @minScore");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters.Sector))
+        {
+            sql.AppendLine(" AND LOWER(ta.sector) = LOWER(@sector)");
+        }
+
+        sql.AppendLine(" ORDER BY o.score DESC, o.captured_at DESC;");
+
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = new MySqlCommand(sql.ToString(), connection);
+
+        if (filters.MinScore.HasValue)
+        {
+            command.Parameters.AddWithValue("@minScore", filters.MinScore.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters.Sector))
+        {
+            command.Parameters.AddWithValue("@sector", filters.Sector);
+        }
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        var results = new List<Opportunity>();
+
+        var tickerOrdinal = reader.GetOrdinal("ticker");
+        var companyNameOrdinal = reader.GetOrdinal("company_name");
+        var sectorOrdinal = reader.GetOrdinal("sector");
+        var currentPriceOrdinal = reader.GetOrdinal("current_price");
+        var targetPriceOrdinal = reader.GetOrdinal("target_price");
+        var scoreOrdinal = reader.GetOrdinal("score");
+        var thesisOrdinal = reader.GetOrdinal("thesis");
+        var capturedAtOrdinal = reader.GetOrdinal("captured_at");
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var capturedAt = DateTime.SpecifyKind(
+                reader.GetDateTime(capturedAtOrdinal),
+                DateTimeKind.Utc);
+
+            results.Add(
+                new Opportunity(
+                    reader.GetString(tickerOrdinal),
+                    reader.GetString(companyNameOrdinal),
+                    reader.GetString(sectorOrdinal),
+                    reader.GetDecimal(currentPriceOrdinal),
+                    reader.GetDecimal(targetPriceOrdinal),
+                    reader.GetInt32(scoreOrdinal),
+                    reader.GetString(thesisOrdinal),
+                    new DateTimeOffset(capturedAt)));
+        }
+
+        return results;
+    }
+}

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/RadarBolsaDbConnectionFactory.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/RadarBolsaDbConnectionFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Configuration;
+using MySqlConnector;
+
+namespace RadarBolsa.Infrastructure.Persistence;
+
+internal sealed class RadarBolsaDbConnectionFactory(IConfiguration configuration)
+    : IRadarBolsaDbConnectionFactory
+{
+    private readonly string _connectionString =
+        configuration.GetConnectionString("RadarBolsa")
+        ?? throw new InvalidOperationException(
+            "Connection string 'RadarBolsa' was not configured.");
+
+    public MySqlConnection CreateConnection() => new(_connectionString);
+}

--- a/src/backend/RadarBolsa.Infrastructure/RadarBolsa.Infrastructure.csproj
+++ b/src/backend/RadarBolsa.Infrastructure/RadarBolsa.Infrastructure.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -9,7 +9,11 @@
   <ItemGroup>
     <ProjectReference Include="..\RadarBolsa.Application\RadarBolsa.Application.csproj" />
     <ProjectReference Include="..\RadarBolsa.Domain\RadarBolsa.Domain.csproj" />
-    <ProjectReference Include="..\RadarBolsa.Infrastructure\RadarBolsa.Infrastructure.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySqlConnector" Version="2.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## O que foi feito
- reorganiza o backend em Clean Architecture simples com projetos Domain, Application, Infrastructure e Api
- substitui o endpoint de oportunidades por leitura real do MySQL
- adiciona seed inicial idempotente e ajusta o build Docker para os novos projetos

## Como testar
- dotnet build src\\backend\\RadarBolsa.Api\\RadarBolsa.Api.csproj -v minimal
- docker compose up --build -d
- GET http://localhost:8081/health
- GET http://localhost:8081/api/opportunities
- GET http://localhost:8081/api/opportunities?minScore=80
- GET http://localhost:8081/api/opportunities?sector=Energia

## Riscos
- o seed automatico roda na primeira inicializacao de um volume novo do MySQL
- a evolucao do schema ainda depende de scripts SQL versionados no repositorio