### PR TITLE
Cadastro de ativos monitorados

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ curl.exe -i http://localhost:8081/health
 - `GET /api/opportunities`
 - `GET /api/opportunities?minScore=80`
 - `GET /api/opportunities?sector=Energia`
+- `GET /api/tracked-assets`
+- `GET /api/tracked-assets/{ticker}`
+- `POST /api/tracked-assets`
 
 ## Proximas etapas
 1. Adicionar seed inicial de oportunidades no MySQL.

--- a/src/backend/RadarBolsa.Api/Contracts/CreateTrackedAssetRequest.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/CreateTrackedAssetRequest.cs
@@ -1,0 +1,6 @@
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed record CreateTrackedAssetRequest(
+    string Ticker,
+    string CompanyName,
+    string Sector);

--- a/src/backend/RadarBolsa.Api/Contracts/TrackedAssetResponse.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/TrackedAssetResponse.cs
@@ -1,0 +1,9 @@
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed record TrackedAssetResponse(
+    long Id,
+    string Ticker,
+    string CompanyName,
+    string Sector,
+    bool IsActive,
+    DateTimeOffset CreatedAt);

--- a/src/backend/RadarBolsa.Api/Endpoints/TrackedAssetEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/TrackedAssetEndpoints.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using RadarBolsa.Api.Contracts;
+using RadarBolsa.Api.Mappings;
+using RadarBolsa.Application.TrackedAssets;
+
+namespace RadarBolsa.Api.Endpoints;
+
+public static class TrackedAssetEndpoints
+{
+    public static IEndpointRouteBuilder MapTrackedAssetEndpoints(
+        this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/tracked-assets");
+
+        group.MapGet("/", GetTrackedAssets)
+            .WithName("GetTrackedAssets");
+
+        group.MapGet("/{ticker}", GetTrackedAssetByTicker)
+            .WithName("GetTrackedAssetByTicker");
+
+        group.MapPost("/", CreateTrackedAsset)
+            .WithName("CreateTrackedAsset");
+
+        return app;
+    }
+
+    private static async Task<Ok<TrackedAssetResponse[]>> GetTrackedAssets(
+        GetTrackedAssetsUseCase useCase,
+        CancellationToken cancellationToken)
+    {
+        var trackedAssets = await useCase.ExecuteAsync(cancellationToken);
+
+        return TypedResults.Ok(
+            trackedAssets
+                .Select(item => item.ToResponse())
+                .ToArray());
+    }
+
+    private static async Task<Results<Ok<TrackedAssetResponse>, NotFound>> GetTrackedAssetByTicker(
+        string ticker,
+        GetTrackedAssetByTickerUseCase useCase,
+        CancellationToken cancellationToken)
+    {
+        var trackedAsset = await useCase.ExecuteAsync(ticker, cancellationToken);
+
+        if (trackedAsset is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        return TypedResults.Ok(trackedAsset.ToResponse());
+    }
+
+    private static async Task<Created<TrackedAssetResponse>> CreateTrackedAsset(
+        CreateTrackedAssetRequest request,
+        CreateTrackedAssetUseCase useCase,
+        CancellationToken cancellationToken)
+    {
+        var trackedAsset = await useCase.ExecuteAsync(
+            request.ToInput(),
+            cancellationToken);
+
+        var response = trackedAsset.ToResponse();
+
+        return TypedResults.Created(
+            $"/api/tracked-assets/{response.Ticker}",
+            response);
+    }
+}

--- a/src/backend/RadarBolsa.Api/Endpoints/TrackedAssetEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/TrackedAssetEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using RadarBolsa.Api.Contracts;
 using RadarBolsa.Api.Mappings;
 using RadarBolsa.Application.TrackedAssets;
@@ -51,16 +52,29 @@ public static class TrackedAssetEndpoints
         return TypedResults.Ok(trackedAsset.ToResponse());
     }
 
-    private static async Task<Created<TrackedAssetResponse>> CreateTrackedAsset(
+    private static async Task<Results<Created<TrackedAssetResponse>, ValidationProblem, ProblemHttpResult>> CreateTrackedAsset(
         CreateTrackedAssetRequest request,
         CreateTrackedAssetUseCase useCase,
         CancellationToken cancellationToken)
     {
-        var trackedAsset = await useCase.ExecuteAsync(
+        var result = await useCase.ExecuteAsync(
             request.ToInput(),
             cancellationToken);
 
-        var response = trackedAsset.ToResponse();
+        if (result.Status == CreateTrackedAssetStatus.ValidationError)
+        {
+            return TypedResults.ValidationProblem(result.Errors);
+        }
+
+        if (result.Status == CreateTrackedAssetStatus.Conflict)
+        {
+            return TypedResults.Problem(
+                title: "Tracked asset already exists",
+                detail: result.ConflictMessage,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        var response = result.TrackedAsset!.ToResponse();
 
         return TypedResults.Created(
             $"/api/tracked-assets/{response.Ticker}",

--- a/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
+++ b/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
@@ -1,5 +1,7 @@
 using RadarBolsa.Api.Contracts;
 using RadarBolsa.Domain.Opportunities;
+using RadarBolsa.Domain.TrackedAssets;
+using RadarBolsa.Application.TrackedAssets;
 
 namespace RadarBolsa.Api.Mappings;
 
@@ -15,4 +17,20 @@ internal static class ApiContractMappings
             opportunity.Score,
             opportunity.Thesis,
             opportunity.CapturedAt);
+
+    public static CreateTrackedAssetInput ToInput(
+        this CreateTrackedAssetRequest request) =>
+        new(
+            request.Ticker,
+            request.CompanyName,
+            request.Sector);
+
+    public static TrackedAssetResponse ToResponse(this TrackedAsset trackedAsset) =>
+        new(
+            trackedAsset.Id,
+            trackedAsset.Ticker,
+            trackedAsset.CompanyName,
+            trackedAsset.Sector,
+            trackedAsset.IsActive,
+            trackedAsset.CreatedAt);
 }

--- a/src/backend/RadarBolsa.Api/Program.cs
+++ b/src/backend/RadarBolsa.Api/Program.cs
@@ -15,5 +15,6 @@ app.UseCors(CorsPolicies.Frontend);
 
 app.MapHealthEndpoints();
 app.MapOpportunityEndpoints();
+app.MapTrackedAssetEndpoints();
 
 app.Run();

--- a/src/backend/RadarBolsa.Application/Abstractions/Persistence/ITrackedAssetRepository.cs
+++ b/src/backend/RadarBolsa.Application/Abstractions/Persistence/ITrackedAssetRepository.cs
@@ -1,0 +1,17 @@
+using RadarBolsa.Application.TrackedAssets;
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Application.Abstractions.Persistence;
+
+public interface ITrackedAssetRepository
+{
+    Task<TrackedAsset> AddAsync(
+        CreateTrackedAssetInput input,
+        CancellationToken cancellationToken);
+
+    Task<TrackedAsset?> FindByTickerAsync(
+        string ticker,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TrackedAsset>> ListAsync(CancellationToken cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/DependencyInjection.cs
+++ b/src/backend/RadarBolsa.Application/DependencyInjection.cs
@@ -13,6 +13,7 @@ public static class DependencyInjection
         services.AddScoped<GetOpportunitiesUseCase>();
         services.AddScoped<CreateTrackedAssetUseCase>();
         services.AddScoped<GetTrackedAssetsUseCase>();
+        services.AddScoped<GetTrackedAssetByTickerUseCase>();
 
         return services;
     }

--- a/src/backend/RadarBolsa.Application/DependencyInjection.cs
+++ b/src/backend/RadarBolsa.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using RadarBolsa.Application.Health;
 using RadarBolsa.Application.Opportunities;
+using RadarBolsa.Application.TrackedAssets;
 
 namespace RadarBolsa.Application;
 
@@ -10,6 +11,8 @@ public static class DependencyInjection
     {
         services.AddScoped<GetHealthStatusUseCase>();
         services.AddScoped<GetOpportunitiesUseCase>();
+        services.AddScoped<CreateTrackedAssetUseCase>();
+        services.AddScoped<GetTrackedAssetsUseCase>();
 
         return services;
     }

--- a/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetInput.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetInput.cs
@@ -1,0 +1,6 @@
+namespace RadarBolsa.Application.TrackedAssets;
+
+public sealed record CreateTrackedAssetInput(
+    string Ticker,
+    string CompanyName,
+    string Sector);

--- a/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetResult.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetResult.cs
@@ -1,0 +1,30 @@
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Application.TrackedAssets;
+
+public enum CreateTrackedAssetStatus
+{
+    Success,
+    ValidationError,
+    Conflict
+}
+
+public sealed record CreateTrackedAssetResult(
+    CreateTrackedAssetStatus Status,
+    TrackedAsset? TrackedAsset,
+    IReadOnlyDictionary<string, string[]> Errors,
+    string? ConflictMessage)
+{
+    public static CreateTrackedAssetResult Success(TrackedAsset trackedAsset) =>
+        new(CreateTrackedAssetStatus.Success, trackedAsset, EmptyErrors, null);
+
+    public static CreateTrackedAssetResult ValidationError(
+        IReadOnlyDictionary<string, string[]> errors) =>
+        new(CreateTrackedAssetStatus.ValidationError, null, errors, null);
+
+    public static CreateTrackedAssetResult Conflict(string message) =>
+        new(CreateTrackedAssetStatus.Conflict, null, EmptyErrors, message);
+
+    private static IReadOnlyDictionary<string, string[]> EmptyErrors { get; } =
+        new Dictionary<string, string[]>();
+}

--- a/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetUseCase.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetUseCase.cs
@@ -1,0 +1,20 @@
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Application.TrackedAssets;
+
+public sealed class CreateTrackedAssetUseCase(
+    ITrackedAssetRepository trackedAssetRepository)
+{
+    public Task<TrackedAsset> ExecuteAsync(
+        CreateTrackedAssetInput input,
+        CancellationToken cancellationToken)
+    {
+        var normalizedInput = new CreateTrackedAssetInput(
+            input.Ticker.Trim().ToUpperInvariant(),
+            input.CompanyName.Trim(),
+            input.Sector.Trim());
+
+        return trackedAssetRepository.AddAsync(normalizedInput, cancellationToken);
+    }
+}

--- a/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetUseCase.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/CreateTrackedAssetUseCase.cs
@@ -1,20 +1,118 @@
 using RadarBolsa.Application.Abstractions.Persistence;
-using RadarBolsa.Domain.TrackedAssets;
 
 namespace RadarBolsa.Application.TrackedAssets;
 
 public sealed class CreateTrackedAssetUseCase(
     ITrackedAssetRepository trackedAssetRepository)
 {
-    public Task<TrackedAsset> ExecuteAsync(
+    public async Task<CreateTrackedAssetResult> ExecuteAsync(
         CreateTrackedAssetInput input,
         CancellationToken cancellationToken)
     {
         var normalizedInput = new CreateTrackedAssetInput(
-            input.Ticker.Trim().ToUpperInvariant(),
-            input.CompanyName.Trim(),
-            input.Sector.Trim());
+            NormalizeTicker(input.Ticker),
+            NormalizeText(input.CompanyName),
+            NormalizeText(input.Sector));
 
-        return trackedAssetRepository.AddAsync(normalizedInput, cancellationToken);
+        var errors = Validate(normalizedInput);
+
+        if (errors.Count > 0)
+        {
+            return CreateTrackedAssetResult.ValidationError(errors);
+        }
+
+        var existingTrackedAsset = await trackedAssetRepository.FindByTickerAsync(
+            normalizedInput.Ticker,
+            cancellationToken);
+
+        if (existingTrackedAsset is not null)
+        {
+            return CreateTrackedAssetResult.Conflict(
+                $"Tracked asset '{normalizedInput.Ticker}' is already registered.");
+        }
+
+        try
+        {
+            var trackedAsset = await trackedAssetRepository.AddAsync(
+                normalizedInput,
+                cancellationToken);
+
+            return CreateTrackedAssetResult.Success(trackedAsset);
+        }
+        catch (TrackedAssetAlreadyExistsException)
+        {
+            return CreateTrackedAssetResult.Conflict(
+                $"Tracked asset '{normalizedInput.Ticker}' is already registered.");
+        }
+    }
+
+    private static string NormalizeTicker(string? ticker) =>
+        (ticker ?? string.Empty).Trim().ToUpperInvariant();
+
+    private static string NormalizeText(string? value) =>
+        (value ?? string.Empty).Trim();
+
+    private static Dictionary<string, string[]> Validate(CreateTrackedAssetInput input)
+    {
+        var errors = new Dictionary<string, string[]>();
+
+        if (string.IsNullOrWhiteSpace(input.Ticker))
+        {
+            errors["ticker"] = ["Ticker is required."];
+        }
+        else
+        {
+            var tickerErrors = new List<string>();
+
+            if (input.Ticker.Length is < 4 or > 12)
+            {
+                tickerErrors.Add("Ticker must have between 4 and 12 characters.");
+            }
+
+            if (!input.Ticker.All(char.IsLetterOrDigit))
+            {
+                tickerErrors.Add("Ticker must contain only letters and numbers.");
+            }
+
+            if (tickerErrors.Count > 0)
+            {
+                errors["ticker"] = tickerErrors.ToArray();
+            }
+        }
+
+        ValidateRequiredText(
+            errors,
+            "companyName",
+            input.CompanyName,
+            120,
+            "Company name");
+
+        ValidateRequiredText(
+            errors,
+            "sector",
+            input.Sector,
+            80,
+            "Sector");
+
+        return errors;
+    }
+
+    private static void ValidateRequiredText(
+        IDictionary<string, string[]> errors,
+        string field,
+        string value,
+        int maxLength,
+        string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errors[field] = [$"{label} is required."];
+            return;
+        }
+
+        if (value.Length > maxLength)
+        {
+            errors[field] = [$"{label} must have at most {maxLength} characters."];
+        }
     }
 }

--- a/src/backend/RadarBolsa.Application/TrackedAssets/GetTrackedAssetByTickerUseCase.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/GetTrackedAssetByTickerUseCase.cs
@@ -1,0 +1,13 @@
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Application.TrackedAssets;
+
+public sealed class GetTrackedAssetByTickerUseCase(
+    ITrackedAssetRepository trackedAssetRepository)
+{
+    public Task<TrackedAsset?> ExecuteAsync(
+        string ticker,
+        CancellationToken cancellationToken) =>
+        trackedAssetRepository.FindByTickerAsync(ticker, cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/TrackedAssets/GetTrackedAssetsUseCase.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/GetTrackedAssetsUseCase.cs
@@ -1,0 +1,12 @@
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Application.TrackedAssets;
+
+public sealed class GetTrackedAssetsUseCase(
+    ITrackedAssetRepository trackedAssetRepository)
+{
+    public Task<IReadOnlyList<TrackedAsset>> ExecuteAsync(
+        CancellationToken cancellationToken) =>
+        trackedAssetRepository.ListAsync(cancellationToken);
+}

--- a/src/backend/RadarBolsa.Application/TrackedAssets/TrackedAssetAlreadyExistsException.cs
+++ b/src/backend/RadarBolsa.Application/TrackedAssets/TrackedAssetAlreadyExistsException.cs
@@ -1,0 +1,7 @@
+namespace RadarBolsa.Application.TrackedAssets;
+
+public sealed class TrackedAssetAlreadyExistsException(string ticker)
+    : Exception($"Tracked asset '{ticker}' already exists.")
+{
+    public string Ticker { get; } = ticker;
+}

--- a/src/backend/RadarBolsa.Domain/TrackedAssets/TrackedAsset.cs
+++ b/src/backend/RadarBolsa.Domain/TrackedAssets/TrackedAsset.cs
@@ -1,0 +1,9 @@
+namespace RadarBolsa.Domain.TrackedAssets;
+
+public sealed record TrackedAsset(
+    long Id,
+    string Ticker,
+    string CompanyName,
+    string Sector,
+    bool IsActive,
+    DateTimeOffset CreatedAt);

--- a/src/backend/RadarBolsa.Infrastructure/DependencyInjection.cs
+++ b/src/backend/RadarBolsa.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using RadarBolsa.Application.Abstractions.Persistence;
 using RadarBolsa.Infrastructure.Health;
 using RadarBolsa.Infrastructure.Persistence;
 using RadarBolsa.Infrastructure.Persistence.Opportunities;
+using RadarBolsa.Infrastructure.Persistence.TrackedAssets;
 
 namespace RadarBolsa.Infrastructure;
 
@@ -14,6 +15,7 @@ public static class DependencyInjection
         services.AddSingleton<IRadarBolsaDbConnectionFactory, RadarBolsaDbConnectionFactory>();
         services.AddSingleton<IDatabaseHealthChecker, DatabaseHealthChecker>();
         services.AddScoped<IOpportunityReadRepository, MySqlOpportunityReadRepository>();
+        services.AddScoped<ITrackedAssetRepository, MySqlTrackedAssetRepository>();
 
         return services;
     }

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/TrackedAssets/MySqlTrackedAssetRepository.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/TrackedAssets/MySqlTrackedAssetRepository.cs
@@ -33,7 +33,14 @@ internal sealed class MySqlTrackedAssetRepository(
         insertCommand.Parameters.AddWithValue("@companyName", input.CompanyName);
         insertCommand.Parameters.AddWithValue("@sector", input.Sector);
 
-        await insertCommand.ExecuteNonQueryAsync(cancellationToken);
+        try
+        {
+            await insertCommand.ExecuteNonQueryAsync(cancellationToken);
+        }
+        catch (MySqlException exception) when (exception.Number == 1062)
+        {
+            throw new TrackedAssetAlreadyExistsException(input.Ticker);
+        }
 
         return await GetByIdAsync(
             insertCommand.LastInsertedId,

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/TrackedAssets/MySqlTrackedAssetRepository.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/TrackedAssets/MySqlTrackedAssetRepository.cs
@@ -1,0 +1,169 @@
+using MySqlConnector;
+using RadarBolsa.Application.Abstractions.Persistence;
+using RadarBolsa.Application.TrackedAssets;
+using RadarBolsa.Domain.TrackedAssets;
+
+namespace RadarBolsa.Infrastructure.Persistence.TrackedAssets;
+
+internal sealed class MySqlTrackedAssetRepository(
+    IRadarBolsaDbConnectionFactory connectionFactory) : ITrackedAssetRepository
+{
+    public async Task<TrackedAsset> AddAsync(
+        CreateTrackedAssetInput input,
+        CancellationToken cancellationToken)
+    {
+        const string insertSql = """
+            INSERT INTO tracked_assets (
+                ticker,
+                company_name,
+                sector,
+                is_active)
+            VALUES (
+                @ticker,
+                @companyName,
+                @sector,
+                b'1');
+            """;
+
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using var insertCommand = new MySqlCommand(insertSql, connection);
+        insertCommand.Parameters.AddWithValue("@ticker", input.Ticker);
+        insertCommand.Parameters.AddWithValue("@companyName", input.CompanyName);
+        insertCommand.Parameters.AddWithValue("@sector", input.Sector);
+
+        await insertCommand.ExecuteNonQueryAsync(cancellationToken);
+
+        return await GetByIdAsync(
+            insertCommand.LastInsertedId,
+            connection,
+            cancellationToken)
+            ?? throw new InvalidOperationException(
+                "Tracked asset was inserted but could not be retrieved.");
+    }
+
+    public async Task<TrackedAsset?> FindByTickerAsync(
+        string ticker,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT
+                id,
+                ticker,
+                company_name,
+                sector,
+                is_active,
+                created_at
+            FROM tracked_assets
+            WHERE ticker = @ticker
+            LIMIT 1;
+            """;
+
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = new MySqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@ticker", ticker.Trim().ToUpperInvariant());
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return MapTrackedAsset(reader);
+    }
+
+    public async Task<IReadOnlyList<TrackedAsset>> ListAsync(
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT
+                id,
+                ticker,
+                company_name,
+                sector,
+                is_active,
+                created_at
+            FROM tracked_assets
+            ORDER BY ticker;
+            """;
+
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = new MySqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        var trackedAssets = new List<TrackedAsset>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            trackedAssets.Add(MapTrackedAsset(reader));
+        }
+
+        return trackedAssets;
+    }
+
+    private static TrackedAsset MapTrackedAsset(MySqlDataReader reader)
+    {
+        var createdAt = DateTime.SpecifyKind(
+            reader.GetDateTime("created_at"),
+            DateTimeKind.Utc);
+
+        return new TrackedAsset(
+            reader.GetInt64("id"),
+            reader.GetString("ticker"),
+            reader.GetString("company_name"),
+            reader.GetString("sector"),
+            ReadBoolean(reader, "is_active"),
+            new DateTimeOffset(createdAt));
+    }
+
+    private static bool ReadBoolean(MySqlDataReader reader, string columnName)
+    {
+        var value = reader.GetValue(reader.GetOrdinal(columnName));
+
+        return value switch
+        {
+            bool booleanValue => booleanValue,
+            ulong integerValue => integerValue == 1,
+            long integerValue => integerValue == 1,
+            byte[] bytes => bytes.Length > 0 && bytes[0] == 1,
+            _ => Convert.ToBoolean(value)
+        };
+    }
+
+    private static async Task<TrackedAsset?> GetByIdAsync(
+        long id,
+        MySqlConnection connection,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT
+                id,
+                ticker,
+                company_name,
+                sector,
+                is_active,
+                created_at
+            FROM tracked_assets
+            WHERE id = @id
+            LIMIT 1;
+            """;
+
+        await using var command = new MySqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", id);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return MapTrackedAsset(reader);
+    }
+}


### PR DESCRIPTION
## O que foi feito
- cria a base de dominio, aplicacao e persistencia para tracked assets
- implementa endpoints GET e POST para ativos monitorados
- adiciona validacoes de cadastro e tratamento de ticker duplicado

## Como testar
- dotnet build src\\backend\\RadarBolsa.Api\\RadarBolsa.Api.csproj -v minimal
- docker compose up --build -d
- GET http://localhost:8081/api/tracked-assets
- GET http://localhost:8081/api/tracked-assets/ITUB4
- POST http://localhost:8081/api/tracked-assets
- POST http://localhost:8081/api/tracked-assets com ticker duplicado para validar 409

## Riscos
- ainda nao ha testes automatizados cobrindo os fluxos de tracked assets
- a camada de validacao esta centralizada no caso de uso e pode evoluir para componentes dedicados no futuro