### PR TITLE
Filtros da API de oportunidades

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ curl.exe -i http://localhost:8081/health
 ## Contrato de oportunidades
 - `GET /api/opportunities` retorna um array JSON simples para consumo direto do frontend.
 - Ordenacao atual: `score` decrescente e, em caso de empate, `capturedAt` mais recente primeiro.
+- Quando nenhum item atende aos filtros, a API responde `200 OK` com array vazio.
+- Quando parametros invalidos sao informados, a API responde `400` com `ValidationProblem`.
 - Parametros de query do MVP:
   - `minScore`: inteiro opcional para retornar apenas oportunidades com score minimo.
   - `sector`: texto opcional para filtrar por setor, sem diferenciar maiusculas e minusculas.
@@ -115,6 +117,8 @@ curl.exe -i http://localhost:8081/health
   - `GET /api/opportunities?minUpside=10&maxUpside=16`
   - `GET /api/opportunities?sortBy=upside`
   - `GET /api/opportunities?sector=Financeiro&sortBy=upside&sortDirection=asc`
+  - `GET /api/opportunities?minScore=abc` retorna `400`
+  - `GET /api/opportunities?minUpside=20&maxUpside=10` retorna `400`
 
 ## Proximas etapas
 1. Adicionar seed inicial de oportunidades no MySQL.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ curl.exe -i http://localhost:8081/health
 - Parametros de query do MVP:
   - `minScore`: inteiro opcional para retornar apenas oportunidades com score minimo.
   - `sector`: texto opcional para filtrar por setor, sem diferenciar maiusculas e minusculas.
+  - `minUpside`: decimal opcional para filtrar upside minimo em percentual.
+  - `maxUpside`: decimal opcional para filtrar upside maximo em percentual.
+  - `sortBy`: texto opcional com `score` ou `upside`. O padrao atual e `score`.
+  - `sortDirection`: texto opcional com `desc` ou `asc`. O padrao atual e `desc`.
 - Campos de resposta por item:
   - `ticker`
   - `companyName`
@@ -107,6 +111,10 @@ curl.exe -i http://localhost:8081/health
   - `GET /api/opportunities?minScore=80`
   - `GET /api/opportunities?sector=Financeiro`
   - `GET /api/opportunities?minScore=75&sector=Energia`
+  - `GET /api/opportunities?minUpside=10`
+  - `GET /api/opportunities?minUpside=10&maxUpside=16`
+  - `GET /api/opportunities?sortBy=upside`
+  - `GET /api/opportunities?sector=Financeiro&sortBy=upside&sortDirection=asc`
 
 ## Proximas etapas
 1. Adicionar seed inicial de oportunidades no MySQL.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ curl.exe -i http://localhost:8081/health
 - `GET /api/tracked-assets/{ticker}`
 - `POST /api/tracked-assets`
 
+## Contrato de oportunidades
+- `GET /api/opportunities` retorna um array JSON simples para consumo direto do frontend.
+- Ordenacao atual: `score` decrescente e, em caso de empate, `capturedAt` mais recente primeiro.
+- Parametros de query do MVP:
+  - `minScore`: inteiro opcional para retornar apenas oportunidades com score minimo.
+  - `sector`: texto opcional para filtrar por setor, sem diferenciar maiusculas e minusculas.
+- Campos de resposta por item:
+  - `ticker`
+  - `companyName`
+  - `sector`
+  - `currentPrice`
+  - `targetPrice`
+  - `score`
+  - `thesis`
+  - `capturedAt`
+  - `upsidePercent`
+- Exemplos:
+  - `GET /api/opportunities`
+  - `GET /api/opportunities?minScore=80`
+  - `GET /api/opportunities?sector=Financeiro`
+  - `GET /api/opportunities?minScore=75&sector=Energia`
+
 ## Proximas etapas
 1. Adicionar seed inicial de oportunidades no MySQL.
 2. Criar cadastro e monitoramento de ativos.

--- a/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
@@ -1,0 +1,8 @@
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed class GetOpportunitiesRequest
+{
+    public int? MinScore { get; init; }
+
+    public string? Sector { get; init; }
+}

--- a/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
@@ -2,13 +2,13 @@ namespace RadarBolsa.Api.Contracts;
 
 internal sealed class GetOpportunitiesRequest
 {
-    public int? MinScore { get; init; }
+    public string? MinScore { get; init; }
 
     public string? Sector { get; init; }
 
-    public decimal? MinUpside { get; init; }
+    public string? MinUpside { get; init; }
 
-    public decimal? MaxUpside { get; init; }
+    public string? MaxUpside { get; init; }
 
     public string? SortBy { get; init; }
 

--- a/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequest.cs
@@ -5,4 +5,12 @@ internal sealed class GetOpportunitiesRequest
     public int? MinScore { get; init; }
 
     public string? Sector { get; init; }
+
+    public decimal? MinUpside { get; init; }
+
+    public decimal? MaxUpside { get; init; }
+
+    public string? SortBy { get; init; }
+
+    public string? SortDirection { get; init; }
 }

--- a/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequestValidationResult.cs
+++ b/src/backend/RadarBolsa.Api/Contracts/GetOpportunitiesRequestValidationResult.cs
@@ -1,0 +1,20 @@
+using RadarBolsa.Application.Opportunities;
+
+namespace RadarBolsa.Api.Contracts;
+
+internal sealed record GetOpportunitiesRequestValidationResult(
+    bool IsValid,
+    OpportunityFilters? Filters,
+    IReadOnlyDictionary<string, string[]> Errors)
+{
+    public static GetOpportunitiesRequestValidationResult Success(
+        OpportunityFilters filters) =>
+        new(true, filters, EmptyErrors);
+
+    public static GetOpportunitiesRequestValidationResult Failure(
+        IReadOnlyDictionary<string, string[]> errors) =>
+        new(false, null, errors);
+
+    private static IReadOnlyDictionary<string, string[]> EmptyErrors { get; } =
+        new Dictionary<string, string[]>();
+}

--- a/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using RadarBolsa.Api.Contracts;
 using RadarBolsa.Api.Mappings;
 using RadarBolsa.Application.Opportunities;
@@ -16,14 +17,12 @@ public static class OpportunityEndpoints
     }
 
     private static async Task<Ok<OpportunityResponse[]>> GetOpportunities(
-        int? minScore,
-        string? sector,
+        [AsParameters] GetOpportunitiesRequest request,
         GetOpportunitiesUseCase useCase,
         CancellationToken cancellationToken)
     {
         var opportunities = await useCase.ExecuteAsync(
-            minScore,
-            sector,
+            request.ToFilters(),
             cancellationToken);
 
         return TypedResults.Ok(

--- a/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
+++ b/src/backend/RadarBolsa.Api/Endpoints/OpportunityEndpoints.cs
@@ -16,13 +16,20 @@ public static class OpportunityEndpoints
         return app;
     }
 
-    private static async Task<Ok<OpportunityResponse[]>> GetOpportunities(
+    private static async Task<Results<Ok<OpportunityResponse[]>, ValidationProblem>> GetOpportunities(
         [AsParameters] GetOpportunitiesRequest request,
         GetOpportunitiesUseCase useCase,
         CancellationToken cancellationToken)
     {
+        var validationResult = request.ValidateAndMap();
+
+        if (!validationResult.IsValid)
+        {
+            return TypedResults.ValidationProblem(validationResult.Errors);
+        }
+
         var opportunities = await useCase.ExecuteAsync(
-            request.ToFilters(),
+            validationResult.Filters!,
             cancellationToken);
 
         return TypedResults.Ok(

--- a/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
+++ b/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using RadarBolsa.Api.Contracts;
 using RadarBolsa.Application.Opportunities;
 using RadarBolsa.Domain.Opportunities;
@@ -8,17 +9,47 @@ namespace RadarBolsa.Api.Mappings;
 
 internal static class ApiContractMappings
 {
-    public static OpportunityFilters ToFilters(
-        this GetOpportunitiesRequest request) =>
-        new(
+    public static GetOpportunitiesRequestValidationResult ValidateAndMap(
+        this GetOpportunitiesRequest request)
+    {
+        var errors = new Dictionary<string, string[]>();
+
+        var minScore = ParseNullableInt(
             request.MinScore,
-            string.IsNullOrWhiteSpace(request.Sector)
-                ? null
-                : request.Sector.Trim(),
-            request.MinUpside,
-            request.MaxUpside,
-            ParseSortBy(request.SortBy),
-            ParseSortDirection(request.SortDirection));
+            "minScore",
+            0,
+            100,
+            errors);
+
+        var minUpside = ParseNullableDecimal(request.MinUpside, "minUpside", errors);
+        var maxUpside = ParseNullableDecimal(request.MaxUpside, "maxUpside", errors);
+
+        if (minUpside.HasValue && maxUpside.HasValue && minUpside > maxUpside)
+        {
+            errors["upsideRange"] =
+            [
+                "minUpside must be less than or equal to maxUpside."
+            ];
+        }
+
+        var sector = NormalizeSector(request.Sector, errors);
+        var sortBy = ParseSortBy(request.SortBy, errors);
+        var sortDirection = ParseSortDirection(request.SortDirection, errors);
+
+        if (errors.Count > 0)
+        {
+            return GetOpportunitiesRequestValidationResult.Failure(errors);
+        }
+
+        return GetOpportunitiesRequestValidationResult.Success(
+            new OpportunityFilters(
+                minScore,
+                sector,
+                minUpside,
+                maxUpside,
+                sortBy,
+                sortDirection));
+    }
 
     public static OpportunityResponse ToResponse(this Opportunity opportunity) =>
         new(
@@ -47,17 +78,113 @@ internal static class ApiContractMappings
             trackedAsset.IsActive,
             trackedAsset.CreatedAt);
 
-    private static OpportunitySortBy ParseSortBy(string? sortBy) =>
+    private static int? ParseNullableInt(
+        string? value,
+        string field,
+        int min,
+        int max,
+        IDictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!int.TryParse(
+                value.Trim(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsedValue))
+        {
+            errors[field] = [$"{field} must be a valid integer."];
+            return null;
+        }
+
+        if (parsedValue < min || parsedValue > max)
+        {
+            errors[field] = [$"{field} must be between {min} and {max}."];
+            return null;
+        }
+
+        return parsedValue;
+    }
+
+    private static decimal? ParseNullableDecimal(
+        string? value,
+        string field,
+        IDictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!decimal.TryParse(
+                value.Trim(),
+                NumberStyles.Number,
+                CultureInfo.InvariantCulture,
+                out var parsedValue))
+        {
+            errors[field] = [$"{field} must be a valid decimal number."];
+            return null;
+        }
+
+        return parsedValue;
+    }
+
+    private static string? NormalizeSector(
+        string? sector,
+        IDictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(sector))
+        {
+            return null;
+        }
+
+        var normalizedSector = sector.Trim();
+
+        if (normalizedSector.Length > 80)
+        {
+            errors["sector"] = ["sector must have at most 80 characters."];
+            return null;
+        }
+
+        return normalizedSector;
+    }
+
+    private static OpportunitySortBy ParseSortBy(
+        string? sortBy,
+        IDictionary<string, string[]> errors) =>
         sortBy?.Trim().ToLowerInvariant() switch
         {
             "upside" => OpportunitySortBy.Upside,
-            _ => OpportunitySortBy.Score
+            null or "" => OpportunitySortBy.Score,
+            "score" => OpportunitySortBy.Score,
+            _ => AddSortByError(errors)
         };
 
-    private static SortDirection ParseSortDirection(string? sortDirection) =>
+    private static SortDirection ParseSortDirection(
+        string? sortDirection,
+        IDictionary<string, string[]> errors) =>
         sortDirection?.Trim().ToLowerInvariant() switch
         {
             "asc" => SortDirection.Asc,
-            _ => SortDirection.Desc
+            null or "" => SortDirection.Desc,
+            "desc" => SortDirection.Desc,
+            _ => AddSortDirectionError(errors)
         };
+
+    private static OpportunitySortBy AddSortByError(
+        IDictionary<string, string[]> errors)
+    {
+        errors["sortBy"] = ["sortBy must be 'score' or 'upside'."];
+        return OpportunitySortBy.Score;
+    }
+
+    private static SortDirection AddSortDirectionError(
+        IDictionary<string, string[]> errors)
+    {
+        errors["sortDirection"] = ["sortDirection must be 'asc' or 'desc'."];
+        return SortDirection.Desc;
+    }
 }

--- a/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
+++ b/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
@@ -1,4 +1,5 @@
 using RadarBolsa.Api.Contracts;
+using RadarBolsa.Application.Opportunities;
 using RadarBolsa.Domain.Opportunities;
 using RadarBolsa.Domain.TrackedAssets;
 using RadarBolsa.Application.TrackedAssets;
@@ -7,6 +8,14 @@ namespace RadarBolsa.Api.Mappings;
 
 internal static class ApiContractMappings
 {
+    public static OpportunityFilters ToFilters(
+        this GetOpportunitiesRequest request) =>
+        new(
+            request.MinScore,
+            string.IsNullOrWhiteSpace(request.Sector)
+                ? null
+                : request.Sector.Trim());
+
     public static OpportunityResponse ToResponse(this Opportunity opportunity) =>
         new(
             opportunity.Ticker,

--- a/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
+++ b/src/backend/RadarBolsa.Api/Mappings/ApiContractMappings.cs
@@ -14,7 +14,11 @@ internal static class ApiContractMappings
             request.MinScore,
             string.IsNullOrWhiteSpace(request.Sector)
                 ? null
-                : request.Sector.Trim());
+                : request.Sector.Trim(),
+            request.MinUpside,
+            request.MaxUpside,
+            ParseSortBy(request.SortBy),
+            ParseSortDirection(request.SortDirection));
 
     public static OpportunityResponse ToResponse(this Opportunity opportunity) =>
         new(
@@ -42,4 +46,18 @@ internal static class ApiContractMappings
             trackedAsset.Sector,
             trackedAsset.IsActive,
             trackedAsset.CreatedAt);
+
+    private static OpportunitySortBy ParseSortBy(string? sortBy) =>
+        sortBy?.Trim().ToLowerInvariant() switch
+        {
+            "upside" => OpportunitySortBy.Upside,
+            _ => OpportunitySortBy.Score
+        };
+
+    private static SortDirection ParseSortDirection(string? sortDirection) =>
+        sortDirection?.Trim().ToLowerInvariant() switch
+        {
+            "asc" => SortDirection.Asc,
+            _ => SortDirection.Desc
+        };
 }

--- a/src/backend/RadarBolsa.Application/Opportunities/GetOpportunitiesUseCase.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/GetOpportunitiesUseCase.cs
@@ -7,14 +7,7 @@ public sealed class GetOpportunitiesUseCase(
     IOpportunityReadRepository opportunityReadRepository)
 {
     public Task<IReadOnlyList<Opportunity>> ExecuteAsync(
-        int? minScore,
-        string? sector,
-        CancellationToken cancellationToken)
-    {
-        var filters = new OpportunityFilters(
-            minScore,
-            string.IsNullOrWhiteSpace(sector) ? null : sector.Trim());
-
-        return opportunityReadRepository.ListAsync(filters, cancellationToken);
-    }
+        OpportunityFilters filters,
+        CancellationToken cancellationToken) =>
+        opportunityReadRepository.ListAsync(filters, cancellationToken);
 }

--- a/src/backend/RadarBolsa.Application/Opportunities/OpportunityFilters.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/OpportunityFilters.cs
@@ -1,3 +1,9 @@
 namespace RadarBolsa.Application.Opportunities;
 
-public sealed record OpportunityFilters(int? MinScore, string? Sector);
+public sealed record OpportunityFilters(
+    int? MinScore,
+    string? Sector,
+    decimal? MinUpside,
+    decimal? MaxUpside,
+    OpportunitySortBy SortBy,
+    SortDirection SortDirection);

--- a/src/backend/RadarBolsa.Application/Opportunities/OpportunitySortBy.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/OpportunitySortBy.cs
@@ -1,0 +1,7 @@
+namespace RadarBolsa.Application.Opportunities;
+
+public enum OpportunitySortBy
+{
+    Score,
+    Upside
+}

--- a/src/backend/RadarBolsa.Application/Opportunities/SortDirection.cs
+++ b/src/backend/RadarBolsa.Application/Opportunities/SortDirection.cs
@@ -1,0 +1,7 @@
+namespace RadarBolsa.Application.Opportunities;
+
+public enum SortDirection
+{
+    Desc,
+    Asc
+}

--- a/src/backend/RadarBolsa.Infrastructure/Persistence/Opportunities/MySqlOpportunityReadRepository.cs
+++ b/src/backend/RadarBolsa.Infrastructure/Persistence/Opportunities/MySqlOpportunityReadRepository.cs
@@ -13,6 +13,14 @@ internal sealed class MySqlOpportunityReadRepository(
         OpportunityFilters filters,
         CancellationToken cancellationToken)
     {
+        const string upsideExpression =
+            """
+            CASE
+                WHEN o.current_price = 0 THEN 0
+                ELSE ((o.target_price - o.current_price) / o.current_price) * 100
+            END
+            """;
+
         var sql = new StringBuilder(
             """
             SELECT
@@ -39,7 +47,26 @@ internal sealed class MySqlOpportunityReadRepository(
             sql.AppendLine(" AND LOWER(ta.sector) = LOWER(@sector)");
         }
 
-        sql.AppendLine(" ORDER BY o.score DESC, o.captured_at DESC;");
+        if (filters.MinUpside.HasValue)
+        {
+            sql.AppendLine($" AND {upsideExpression} >= @minUpside");
+        }
+
+        if (filters.MaxUpside.HasValue)
+        {
+            sql.AppendLine($" AND {upsideExpression} <= @maxUpside");
+        }
+
+        var sortColumn = filters.SortBy == OpportunitySortBy.Upside
+            ? upsideExpression
+            : "o.score";
+
+        var sortDirection = filters.SortDirection == SortDirection.Asc
+            ? "ASC"
+            : "DESC";
+
+        sql.AppendLine(
+            $" ORDER BY {sortColumn} {sortDirection}, o.score DESC, o.captured_at DESC;");
 
         await using var connection = connectionFactory.CreateConnection();
         await connection.OpenAsync(cancellationToken);
@@ -54,6 +81,16 @@ internal sealed class MySqlOpportunityReadRepository(
         if (!string.IsNullOrWhiteSpace(filters.Sector))
         {
             command.Parameters.AddWithValue("@sector", filters.Sector);
+        }
+
+        if (filters.MinUpside.HasValue)
+        {
+            command.Parameters.AddWithValue("@minUpside", filters.MinUpside.Value);
+        }
+
+        if (filters.MaxUpside.HasValue)
+        {
+            command.Parameters.AddWithValue("@maxUpside", filters.MaxUpside.Value);
         }
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);


### PR DESCRIPTION
## O que foi feito
- consolida o contrato do endpoint GET /api/opportunities
- valida e evidencia filtros por score e setor
- adiciona filtro por faixa de upside e ordenacao por upside
- trata parametros invalidos e comportamento de resposta vazia

## Como testar
- dotnet build src\\backend\\RadarBolsa.Api\\RadarBolsa.Api.csproj -v minimal
- docker compose up --build -d
- GET http://localhost:8081/api/opportunities?minScore=80
- GET http://localhost:8081/api/opportunities?minUpside=10&maxUpside=16&sortBy=upside&sortDirection=asc
- GET http://localhost:8081/api/opportunities?sector=Tecnologia
- GET http://localhost:8081/api/opportunities?minScore=abc

## Riscos
- ainda nao ha testes automatizados cobrindo os cenarios dos filtros
- existe uma alteracao local paralela em docs/arquitetura.md que nao faz parte desta PR